### PR TITLE
Update Cloudformation template URL

### DIFF
--- a/1_Lab1.md
+++ b/1_Lab1.md
@@ -130,7 +130,7 @@ For more information, see [Browse the Contents of a Repository](http://docs.aws.
 
 ```console
 user:~/environment/WebAppRepo (master) $ aws cloudformation create-stack --stack-name DevopsWorkshop-roles \
---template-body https://github.com/awslabs/aws-devops-essential/raw/master/templates/01-aws-devops-workshop-roles.template \
+--template-body https://raw.githubusercontent.com/awslabs/aws-devops-essential/master/templates/01-aws-devops-workshop-roles.template \
 --capabilities CAPABILITY_IAM
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
Github redirect causes the following error message
```Error parsing parameter '--template-body': Unable to retrieve https://github.com/awslabs/aws-devops-essential/raw/master/templates/01-aws-devops-workshop-roles.template: received non 200 status code of 302```

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
