### PR TITLE
Update cloudformation template URL

### DIFF
--- a/2_Lab2.md
+++ b/2_Lab2.md
@@ -7,7 +7,7 @@
 
 ```console
 user:~/environment/WebAppRepo (master) $ aws cloudformation create-stack --stack-name DevopsWorkshop-Env \
---template-body https://github.com/awslabs/aws-devops-essential/raw/master/templates/02-aws-devops-workshop-environment-setup.template \
+--template-body https://raw.githubusercontent.com/awslabs/aws-devops-essential/master/templates/02-aws-devops-workshop-environment-setup.template \
 --capabilities CAPABILITY_IAM
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
Github redirect causes the following error message
```Error parsing parameter '--template-body': Unable to retrieve https://github.com/awslabs/aws-devops-essential/raw/master/templates/01-aws-devops-workshop-roles.template: received non 200 status code of 302```

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
