### PR TITLE
'aws sns create-topic' requires a region

### DIFF
--- a/3_Lab3.md
+++ b/3_Lab3.md
@@ -93,7 +93,7 @@ If the action is approved, the pipeline execution resumes. If the action is reje
 1. **Create SNS topic** for Approval notification. And note the **topic ARN** from the result.
 
 ```console
-user:~/environment $ aws sns create-topic --name WebApp-Approval-Topic
+user:~/environment $ aws sns create-topic --name WebApp-Approval-Topic --region <YOUR-REGION>
 ```
 
 2. **Subscribe** to the topic using your email id. **Replace** the **ARN** and **email id** placeholders accordingly.


### PR DESCRIPTION
Update documentation to include the '--region' flag.

```sh
$ aws sns create-topic --name WebApp-Approval-Topic
You must specify a region. You can also configure your region by running "aws configure".
$ aws sns create-topic --name WebApp-Approval-Topic --region us-west-2
{
    "TopicArn": "arn:aws:sns:us-west-2:99999999999:WebApp-Approval-Topic"
}
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
