### PR TITLE
Use correct location for the create-project.json

### DIFF
--- a/1_Lab1.md
+++ b/1_Lab1.md
@@ -180,7 +180,7 @@ user:~/environment/WebAppRepo (master) $ echo $(aws cloudformation describe-stac
 5. Switch to the directory that contains the file you just saved, and run the **_create-project_** command:
 
 ```console
-user:~/environment/WebAppRepo (master) $ aws codebuild create-project --cli-input-json file://create-project.json
+user:~/environment/WebAppRepo (master) $ aws codebuild create-project --cli-input-json file://../create-project.json
 ```
 
 6. Sample output JSON for your reference


### PR DESCRIPTION
*Issue #, if available:* The lab instructs users to create the create-project.json in the ~/environment/ directory. When running `aws codebuild create-project` the user's current directory is ~/environment/WebAppRepo however the file referenced is "file:///create-project.json" which does not match the location based on the user's current directory.

*Description of changes:* The change fixes the command to reference the file in the ~/environment directory assuming the user follows the instructions creating the create-project.json file in the ~/environment directory and is still in ~/environment/WebAppRepo


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
