### PR TITLE
Fix outdated instructions

### DIFF
--- a/1_Lab1.md
+++ b/1_Lab1.md
@@ -57,16 +57,24 @@ Keep an open scratch pad in Cloud9 or a text editor on your local computer for n
 
 In this step, you will connect to the source repository created in the previous step. Here, you use Git to clone and initialize a copy of your empty AWS CodeCommit repository. Then you specify the user name and email address used to annotate your commits.
 
-1. From CodeCommit Console, you can get the **https clone url** link for your repo.
-2. Go to Cloud9 IDE terminal prompt
-3. Run git clone to pull down a copy of the repository into the local repo:
+First, let's install the git-remote-codecommit (GRC) utility, which will assist us with authenticating to CodeCommit. Run the following from the Cloud9 terminal prompt:
 
 ```console
-user:~/environment $ git clone https://git-codecommit.<YOUR-REGION>.amazonaws.com/v1/repos/WebAppRepo
+pip install --user git-remote-codecommit
+```
+
+Now do the following to clone the repository:
+
+1. From CodeCommit Console, go to your repository. Click on the **Clone URL** dropdown and then choose **Clone HTTPS (GRC)**. The URL will be copied to your clipboard.
+2. Go to Cloud9 IDE terminal prompt
+3. Run git clone to pull down a copy of the repository into the local repo, using the URL copied above. It should be something like this:
+
+```console
+user:~/environment $ git clone codecommit::<YOUR-REGION>://WebAppRepo
 
 ```
 
-Provide your Git HTTPs credential when prompted. You would be seeing the following message if cloning is successful. ***warning: You appear to have cloned an empty repository.***
+You would be seeing the following message if cloning is successful. ***warning: You appear to have cloned an empty repository.***
 
 ***
 
@@ -101,19 +109,11 @@ user:~/environment/WebAppRepo/ $ git commit -m "Initial Commit"
 
 **_💡 Tip_** To see details about the commit you just made, run **_git log_**.
 
-5. Run **_git config credential_** to store the credential.
-
-```console
-user:~/environment/WebAppRepo/ $ git config credential.helper store
-```
-
-6. Run **_git push_** to push your commit through the default remote name Git uses for your AWS CodeCommit repository (origin), from the default branch in your local repo (master):
+5. Run **_git push_** to push your commit through the default remote name Git uses for your AWS CodeCommit repository (origin), from the default branch in your local repo (master):
 
 ```console
 user:~/environment/WebAppRepo/ $ git push -u origin master
 ```
-
-Provide your Git HTTPs credential when prompted. Credential helper will store it, hence you won't be asked again for subsequent push.
 
 **_💡 Tip_** After you have pushed files to your AWS CodeCommit repository, you can use the [AWS CodeCommit console](https://console.aws.amazon.com/codecommit/home) to view the contents.
 

--- a/4_Lab4.md
+++ b/4_Lab4.md
@@ -4,27 +4,43 @@
 ### Stage 1: Create a sample Lambda function
 
 1. Go to Cloud9 IDE
-2. On the right hand side-menu, select **AWS Resources**
-3. Expand Lambda, and select **λ+** [Create a lambda function]
-4. Enter Function Name as **MyLambdaFunctionForAWSCodePipeline**
-5. Click **Next**
-6. Select runtime as **Node.js 8.10** and blue print as **empty-nodejs**
-7. Click **Next**
-8. Select Function trigger as **none** and click **Next**
-9. For Role, select **choose an existing role** and select **CodePipelineLambdaExecRole** which we created as part of the Lab 1 setup.
-10. Click **Next** and preview the changes. Once done, click **Finish**.
-![LambdaConfig](./img/Lab4-Lambda-Config.png)
+2. On the left hand side-menu, select **AWS Explorer** (the icon with the AWS logo on it).
+3. Expand the region and right click on **Lambda**. Then select **Create new SAM application**.
+4. Select **nodejs10.x** as the runtime.
+5. Select the **AWS SAM Hello World** template.
+6. Choose the root directory (_MyDevEnvironment_ if you used the same name conventions as we did).
+7. Then enter a name for your app, such as **MyLambdaFunctionForAWSCodePipeline**.
+8. Hit Enter.
 
-**Note:** Cloud9 will create a local Lambda function named MyLambdaFunctionForAWSCodePipeline.
+9. A new directory will be created at the root of your environment. Inside of it, open the file `template.yaml` and replace its contents with the following. Make sure to replace `<CODEPIPELINE_LAMBDA_EXECUTION_ROLE_ARN>` with the complete ARN of the role created as part of the initial CloudFormation stack (you'll find it in the Outputs tab with the key **LambdaRoleArn**):
 
-11. Then **copy** the following code into the Lambda function **index.js** and **save** it.
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 60
+
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: hello-world/
+      Handler: app.lambdaHandler
+      Runtime: nodejs10.x
+      Role: '<CODEPIPELINE_LAMBDA_EXECUTION_ROLE_ARN>'
+
+```
+
+10. Finally, open `hello-world/app.js` and replace its contents with the following:
 
 ```js
 var assert = require('assert');
 var AWS = require('aws-sdk');
 var http = require('http');
 
-exports.handler = function(event, context) {
+exports.lambdaHandler = function(event, context) {
 
     var codepipeline = new AWS.CodePipeline();
 
@@ -117,10 +133,11 @@ exports.handler = function(event, context) {
 };
 ```
 
-12. Lets deploy the modified function by clicking the deploy button as shown below.
-![lambda-deploy](./img/lambda-deploy.png)
+11. To deploy the function, right-click again on Lambda (in the left side menu, in **AWS Explorer**) and choose **Deploy SAM Application** this time.
+12. Select the single available app, as well as the S3 bucket, and provide a name to the CloudFormation stack.
+13. Press Enter.
 
-13. Review the deployment changes by visiting the [Lambda console](https://console.aws.amazon.com/lambda). 
+The console will show the progress of the deployment. Wait until it completes. You can view the deployed function in the [Lambda console](https://console.aws.amazon.com/lambda).
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ See the diagram below for a depiction of the complete architecture.
 
 ## Prerequisites
 
-* **Configure AWS CodeCommit:** The easiest way to set up AWS CodeCommit is to configure HTTPS Git credentials for AWS CodeCommit. On the user details page in IAM console, choose the **Security Credentials** tab, and in **HTTPS Git credentials for AWS CodeCommit**, choose **Generate**. ![HTTPS Git Credential](./img/codecommit-iam-gc1.png)
-        **💡 Note:** Make Note of the Git HTTP credentials handy. It will be used for cloning and pushing changes to Repo.
-          Also, You can find detail instruction on how to configure HTTPS Git Credential [here](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-gc.html)
-* **IAM Permissions:** Finally, for the AWS account ensure you have sufficient privileges. You must have permissions for the following services:
+* **IAM Permissions:** Ensure your user has sufficient privileges in the AWS account of your choice. You must have permissions for the following services:
 
 AWS Identity and Access Management
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR fixes some outdated steps and adds some improvements. Namely:

1. In Lab 1, instead of using Git HTTPS credentials it now takes advantage of the git-remote-codecommit (GRC) helper. This also ensures that the lab can be run using Event Engine.
2. In Lab 4, instructions have been fixed to ensure they match the new Cloud9 interface.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
